### PR TITLE
feat: refresh login UI and harden first-load language detection

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -28,8 +28,10 @@ i18n.use(initReactI18next).init({
 });
 
 export function setLanguage(lang: string) {
-  i18n.changeLanguage(lang);
-  localStorage.setItem(STORAGE_KEY, lang);
+  const supported = ['en', 'it', 'es', 'de'];
+  const safeLang = supported.includes(lang) ? lang : 'en';
+  i18n.changeLanguage(safeLang);
+  localStorage.setItem(STORAGE_KEY, safeLang);
 }
 
 export default i18n;

--- a/frontend/src/i18n/utils.test.ts
+++ b/frontend/src/i18n/utils.test.ts
@@ -14,6 +14,10 @@ describe('detectLanguage', () => {
     expect(detectLanguage(null, 'de-DE')).toBe('de');
   });
 
+  it('ignores unsupported stored language and falls back to browser', () => {
+    expect(detectLanguage('fr', 'it-IT')).toBe('it');
+  });
+
   it('falls back to english', () => {
     expect(detectLanguage(null, 'pt-BR')).toBe('en');
   });

--- a/frontend/src/i18n/utils.ts
+++ b/frontend/src/i18n/utils.ts
@@ -2,7 +2,10 @@ export function detectLanguage(
   storedLanguage: string | null,
   browserLanguage: string | null
 ): string {
-  if (storedLanguage) return storedLanguage;
+  const supported = new Set(['en', 'it', 'es', 'de']);
+  if (storedLanguage && supported.has(storedLanguage)) {
+    return storedLanguage;
+  }
 
   const lang = (browserLanguage ?? '').toLowerCase();
   if (lang.startsWith('it')) return 'it';

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -37,40 +37,43 @@ export default function Login({
   };
 
   return (
-    <div className="page">
-      <div className="card narrow">
-        <div className="login-brand">
-          <img
-            src="/ring_intercom_logo.png"
-            alt="Ring Intercom Control logo"
-            className="login-logo"
-          />
+    <div className="page login-page">
+      <div className="login-shell">
+        <div className="login-topline" />
+        <div className="card narrow login-card">
+          <div className="login-brand">
+            <img
+              src="/ring_intercom_logo.png"
+              alt="Ring Intercom Control logo"
+              className="login-logo"
+            />
+          </div>
+          <h1>{t('login.title')}</h1>
+          <p className="login-subtitle">{t('login.subtitle')}</p>
+          <form onSubmit={handleSubmit} className="stack">
+            <label className="field">
+              <span>{t('login.username')}</span>
+              <input
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                autoComplete="username"
+              />
+            </label>
+            <label className="field">
+              <span>{t('login.password')}</span>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+              />
+            </label>
+            {error ? <div className="error">{error}</div> : null}
+            <button className="btn login-button" disabled={loading}>
+              {loading ? t('login.signing_in') : t('login.sign_in')}
+            </button>
+          </form>
         </div>
-        <h1>{t('login.title')}</h1>
-        <p>{t('login.subtitle')}</p>
-        <form onSubmit={handleSubmit} className="stack">
-          <label className="field">
-            <span>{t('login.username')}</span>
-            <input
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              autoComplete="username"
-            />
-          </label>
-          <label className="field">
-            <span>{t('login.password')}</span>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete="current-password"
-            />
-          </label>
-          {error ? <div className="error">{error}</div> : null}
-          <button className="btn" disabled={loading}>
-            {loading ? t('login.signing_in') : t('login.sign_in')}
-          </button>
-        </form>
       </div>
     </div>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -56,16 +56,52 @@ body {
   object-fit: contain;
 }
 
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 48px;
+}
+
+.login-shell {
+  width: min(460px, 100%);
+}
+
+.login-topline {
+  height: 4px;
+  width: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #0f6f6f, #49a6a3);
+  margin-bottom: 14px;
+}
+
+.login-card {
+  padding: 28px;
+}
+
 .login-brand {
   display: flex;
   justify-content: center;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
 .login-logo {
-  width: 72px;
-  height: 72px;
+  width: 88px;
+  height: 88px;
   object-fit: contain;
+}
+
+.login-subtitle {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.login-card h1 {
+  text-align: center;
+}
+
+.login-button {
+  width: 100%;
 }
 
 h1,


### PR DESCRIPTION
## Summary
This PR redesigns the login page to a cleaner centered linear layout and improves i18n behavior so first-load language consistently follows browser locale when no valid saved language exists.

## Type of change
- [ ] bug fix
- [X] feature
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] ci
- [ ] security

## Scope
- Frontend:


## Validation
- [ ] `backend` build passes (`npm run build`)
- [ ] `frontend` build passes (`npm run build`)
- [ ] Tests pass (`npm test` where applicable)
- [ ] Smoke checks pass (`scripts/smoke-test.*`)

## Checklist
- [X] No secrets added
- [X] README/docs updated (if needed)
- [X] i18n keys updated in all locales (if UI text changed)
- [X] Branch target is correct (`dev` for feature work, `main` for release/hotfix)

## Related issues

## Screenshots / logs (if relevant)
<img width="1501" height="831" alt="image" src="https://github.com/user-attachments/assets/4db5cc94-7733-4da8-b9a3-7facc7774f0b" />

###Mobile
<img width="469" height="675" alt="image" src="https://github.com/user-attachments/assets/6bda77da-4eff-4035-af52-8c8f24439bb8" />
