### PR TITLE
docs(readme): streamline README and make Docusaurus the source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Most project details are maintained in Docusaurus:
 
 If published with GitHub Pages, docs URL is typically:
 - `https://mrgionsi.github.io/`
+- Public docs link (placeholder): `TODO: add docs URL`
 
 ## Key Capabilities
 
@@ -74,6 +75,23 @@ App URLs:
 - Backend: `http://localhost:3001`
 
 For complete setup, security, Docker, and CI/CD instructions, use the Docusaurus docs above.
+
+## Docker Deployment
+
+The project supports containerized deployment for both backend and frontend.
+
+- Backend image: `backend/Dockerfile`
+- Frontend image: `frontend/Dockerfile`
+- Compose stack: `docker-compose/docker-compose.yml`
+- Env template: `docker-compose/.env.example`
+
+Quick run with Compose:
+
+```bash
+cd docker-compose
+cp .env.example .env
+docker compose up -d
+```
 
 ## Community
 


### PR DESCRIPTION
## Summary
- Refactors README to be concise and non-redundant now that detailed documentation lives in Docusaurus.
- Adds project logo at the top, updates naming to “Ring Intercom Control,” and keeps essential quick-start and screenshots.
- Highlights B&B temporary guest-link use case and supported languages, while linking readers to docs pages for full implementation details.
- 
## Type of change
- [ ] bug fix
- [ ] feature
- [x] docs
- [ ] refactor
- [ ] test
- [ ] ci
- [ ] security

## Scope
- Backend:
- Frontend:
- CI/DevOps:
- Docs:

## Validation
- [ ] `backend` build passes (`npm run build`)
- [ ] `frontend` build passes (`npm run build`)
- [ ] Tests pass (`npm test` where applicable)
- [ ] Smoke checks pass (`scripts/smoke-test.*`)

## Checklist
- [ ] No secrets added
- [x] README/docs updated (if needed)
- [ ] i18n keys updated in all locales (if UI text changed)
- [ ] Branch target is correct (`dev` for feature work, `main` for release/hotfix)

## Related issues

## Screenshots / logs (if relevant)
