### PR TITLE
Add GitHub Actions workflow to deploy Docusaurus docs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-website-pages.yml
+++ b/.github/workflows/deploy-website-pages.yml
@@ -1,0 +1,62 @@
+name: Deploy Website (GitHub Pages)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-website-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build website
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Adds a new GitHub Actions workflow to build and deploy the website/ Docusaurus docs to GitHub Pages.
Triggers on pushes to main when website/** changes and supports manual runs (workflow_dispatch).
Uses Node 20.19.0, uploads the built website/build artifact, and deploys via actions/deploy-pages.
Requires repository Pages settings to use GitHub Actions as the deployment source.

## Reference docs
- Contribution guide: `CONTRIBUTING.md`
- Security policy: `SECURITY.md`
- Support policy: `SUPPORT.md`

## Type of change
- [ ] bug fix
- [ ] feature
- [x] docs
- [ ] refactor
- [ ] test
- [x] ci
- [ ] security

## Scope
- Backend:
- Frontend:
- CI/DevOps:
- Docs:

## Validation
- [ ] `backend` build passes (`npm run build`)
- [ ] `frontend` build passes (`npm run build`)
- [ ] Tests pass (`npm test` where applicable)
- [ ] Smoke checks pass (`scripts/smoke-test.*`)

## Checklist
- [ ] No secrets added
- [ ] README/docs updated (if needed)
- [ ] i18n keys updated in all locales (if UI text changed)
- [ ] Branch target is correct (`dev` for feature work, `main` for release/hotfix)
- [ ] I reviewed `CONTRIBUTING.md` for branch/commit/PR rules
- [ ] I reviewed `SECURITY.md` and handled sensitive changes safely

## Related issues
- Closes #

## Screenshots / logs (if relevant)
- Add screenshots for UI changes and logs for backend/CI issues.
